### PR TITLE
Spackless

### DIFF
--- a/var/spack/environments/configs/gissversions.yaml
+++ b/var/spack/environments/configs/gissversions.yaml
@@ -29,8 +29,6 @@ packages:
         version: [3.1.0]
 
     # --------- Our Stuff
-    modele-utils:
-        version: [cmake]
     ibmisc:
         variants: [+everytrace]
     icebin:

--- a/var/spack/environments/configs/spackless.yaml
+++ b/var/spack/environments/configs/spackless.yaml
@@ -42,4 +42,26 @@ packages:
       paths:
         perl: /gpfsm/dnb33/kmankoff/local/mambaforge/envs/spackless
 
+    py-cython:
+      buildable: false
+      version: [0.28.5]
+      paths:
+        py-cython: /gpfsm/dnb33/kmankoff/local/mambaforge/envs/spackless
+        
+    python:
+      buildable: false
+      version: [3.7.12]
+      paths:
+        python: /gpfsm/dnb33/kmankoff/local/mambaforge/envs/spackless
 
+    py-numpy:
+      buildable: false
+      version: [1.15.2]
+      paths:
+        py-numpy: /gpfsm/dnb33/kmankoff/local/mambaforge/envs/spackless
+        
+    udunits2:
+      buildable: false
+      version: [2.2.17]
+      paths:
+        udunits2: /gpfsm/dnb33/kmankoff/local/mambaforge/envs/spackless

--- a/var/spack/environments/configs/spackless.yaml
+++ b/var/spack/environments/configs/spackless.yaml
@@ -1,0 +1,45 @@
+packages:
+
+    cmake:
+        paths:
+            cmake@3.23.1: /usr/local/other/cmake/3.23.1
+        version: [3.23.1]
+        buildable: false
+
+    everytrace:
+      buildable: false
+      version: [0.2.2]
+      paths:
+        everytrace@0.2.2: /discover/nobackup/kmankoff/LIME_spackless/opt
+
+    automake:
+      buildable: false
+      paths:
+        automake: /gpfsm/dnb33/kmankoff/local/mambaforge/envs/spackless
+
+    autoconf:
+      buildable: false
+      paths:
+        autoconf: /gpfsm/dnb33/kmankoff/local/mambaforge/envs/spackless
+        
+    bison:
+      buildable: false
+      paths:
+        bison: /gpfsm/dnb33/kmankoff/local/mambaforge/envs/spackless
+        
+    flex:
+      buildable: false
+      paths:
+        flex: /gpfsm/dnb33/kmankoff/local/mambaforge/envs/spackless
+
+    bzip2:
+      buildable: false
+      paths:
+        bzip2: /gpfsm/dnb33/kmankoff/local/mambaforge/envs/spackless
+        
+    perl:
+      buildable: false
+      paths:
+        perl: /gpfsm/dnb33/kmankoff/local/mambaforge/envs/spackless
+
+

--- a/var/spack/environments/configs/twoway.yaml
+++ b/var/spack/environments/configs/twoway.yaml
@@ -18,11 +18,6 @@ packages:
         variants: [+fortran]
     # netlib-scalapack needs this specific version.
     # https://github.com/spack/spack/issues/10530
-    cmake:
-        paths:
-            cmake@3.23.1: /usr/local/other/cmake/3.23.1
-        version: [3.23.1]
-        buildable: false
 
     # Concretizer bug related to PETSc mess
     # https://github.com/spack/spack/issues/12938
@@ -37,38 +32,3 @@ packages:
 #    petsc:
 #        version: [3.9.0]
 
-    everytrace:
-      buildable: false
-      version: [0.2.2]
-      paths:
-        everytrace@0.2.2: /discover/nobackup/kmankoff/LIME_spackless/opt
-
-    automake:
-      buildable: false
-      paths:
-        automake: /usr
-
-    autoconf:
-      buildable: false
-      paths:
-        autoconf: /usr
-        
-    bison:
-      buildable: false
-      paths:
-        bison: /usr
-        
-    flex:
-      buildable: false
-      paths:
-        flex: /usr
-
-    bzip2:
-      buildable: false
-      paths:
-        bzip2: /usr
-        
-    perl:
-      buildable: false
-      paths:
-        perl: /usr

--- a/var/spack/environments/configs/twoway.yaml
+++ b/var/spack/environments/configs/twoway.yaml
@@ -36,3 +36,9 @@ packages:
 #    # This is the same as was used in spack6/twoway-dev-gibbs
 #    petsc:
 #        version: [3.9.0]
+
+    everytrace:
+      buildable: false
+      version: [0.2.2]
+      paths:
+        everytrace@0.2.2: /discover/nobackup/kmankoff/LIME_intel/opt

--- a/var/spack/environments/configs/twoway.yaml
+++ b/var/spack/environments/configs/twoway.yaml
@@ -20,7 +20,7 @@ packages:
     # https://github.com/spack/spack/issues/10530
     cmake:
         paths:
-            cmake@3.23.1: /usr/local/other/cmake/3.23.1/bin/cmake
+            cmake@3.23.1: /usr/local/other/cmake/3.23.1
         version: [3.23.1]
         buildable: false
 

--- a/var/spack/environments/configs/twoway.yaml
+++ b/var/spack/environments/configs/twoway.yaml
@@ -41,7 +41,7 @@ packages:
       buildable: false
       version: [0.2.2]
       paths:
-        everytrace@0.2.2: /discover/nobackup/kmankoff/LIME_intel/opt
+        everytrace@0.2.2: /discover/nobackup/kmankoff/LIME_spackless/opt
 
     automake:
       buildable: false

--- a/var/spack/environments/configs/twoway.yaml
+++ b/var/spack/environments/configs/twoway.yaml
@@ -42,3 +42,33 @@ packages:
       version: [0.2.2]
       paths:
         everytrace@0.2.2: /discover/nobackup/kmankoff/LIME_intel/opt
+
+    automake:
+      buildable: false
+      paths:
+        automake: /usr
+
+    autoconf:
+      buildable: false
+      paths:
+        autoconf: /usr
+        
+    bison:
+      buildable: false
+      paths:
+        bison: /usr
+        
+    flex:
+      buildable: false
+      paths:
+        flex: /usr
+
+    bzip2:
+      buildable: false
+      paths:
+        bzip2: /usr
+        
+    perl:
+      buildable: false
+      paths:
+        perl: /usr

--- a/var/spack/environments/configs/twoway.yaml
+++ b/var/spack/environments/configs/twoway.yaml
@@ -19,7 +19,10 @@ packages:
     # netlib-scalapack needs this specific version.
     # https://github.com/spack/spack/issues/10530
     cmake:
-        version: [3.12.4]
+        paths:
+            cmake@3.23.1: /usr/local/other/cmake/3.23.1/bin/cmake
+        version: [3.23.1]
+        buildable: false
 
     # Concretizer bug related to PETSc mess
     # https://github.com/spack/spack/issues/12938

--- a/var/spack/environments/tw-discover12/spack.yaml
+++ b/var/spack/environments/tw-discover12/spack.yaml
@@ -4,6 +4,7 @@
 # configuration settings.
 spack:
   include:
+  - ../configs/spackless.yaml        # Highest precedence
   - ../configs/twoway.yaml        # Highest precedence
   - ../configs/gissversions.yaml
   - ../configs/discover12.yaml

--- a/var/spack/environments/tw-discover12/spack.yaml
+++ b/var/spack/environments/tw-discover12/spack.yaml
@@ -45,16 +45,6 @@ spack:
     - pism
     - icebin
     spec: modele
-  - setup: []
-    spec: modele-control
-  - setup: []
-    spec: py-pillow
-  - setup: []
-    spec: modele-utils
-  - setup: []
-    spec: ncview
-  - setup: []
-    spec: nco
   mirrors: {}
   modules:
     enable: []


### PR DESCRIPTION
Spackless can be interpreted two different ways. This PR is, for now, an attempt at less spack. OS/system tools are moved out of spack. Unused packages (e.g, `modele-control`) are also removed.

Eventually, this may grow to no spack - the different definition of spackless.
 
See  NASA-GISS/landice#42

At each step, the entire (remaining) spack dependency graph will be built, and then LIME run for 2 days to check that it gets past NASA-GISS/landice#25

Spack dependency graph prior to this PR is (from `$SPACK/bin/spack -e $SPENV concretize -f`):

```xml
$SPACK/bin/spack -e $SPENV concretize -f
==> Concretizing modele
[+]  b3sftn2  modele@master%intel@20.0.166~aux build_type=RelWithDebInfo copy=standard ~diags+everytrace~fexception~ic+icebin+model~mods+mpi+pnetcdf+tests arch=linux-sles12-x86_64 
[+]  5yvhmqt      ^cmake@3.12.4%intel@20.0.166~doc+ncurses+openssl+ownlibs patches=dd3a40d4d92f6b2158b87d6fb354c277947c776424aa03f6dc8096cf3135f5d0 ~qt arch=linux-sles12-x86_64 
[+]  jue5yne          ^ncurses@6.2%intel@20.0.166~symlinks~termlib arch=linux-sles12-x86_64 
[+]  okxsecl              ^pkgconf@1.5.4%intel@20.0.166 arch=linux-sles12-x86_64 
[+]  uc7xsp6          ^openssl@1.1.1%intel@20.0.166+systemcerts arch=linux-sles12-x86_64 
[+]  zmxapgz              ^perl@5.26.2%intel@20.0.166+cpanm patches=0eac10ed90aeb0459ad8851f88081d439a4e41978e586ec743069e8b059370ac +shared+threads arch=linux-sles12-x86_64 
[+]  5l4h3it                  ^gdbm@1.18.1%intel@20.0.166 arch=linux-sles12-x86_64 
[+]  bqg277o                      ^readline@7.0%intel@20.0.166 arch=linux-sles12-x86_64 
[+]  ke6zypu              ^zlib@1.2.11%intel@20.0.166+optimize+pic+shared arch=linux-sles12-x86_64 
[+]  qdgdt4q      ^everytrace@0.2.2%intel@20.0.166 build_type=RelWithDebInfo copy=standard +cxx+fortran+mpi arch=linux-sles12-x86_64 
[+]  2xi6red          ^intel-mpi@2020.0.166%intel@20.0.166 arch=linux-sles12-x86_64 
[+]  4dsr5dv      ^icebin@0.2.1%intel@20.0.166 build_type=RelWithDebInfo copy=standard +coupler~doc+googletest+gridgen+modele+pism+python arch=linux-sles12-x86_64 
[+]  cvkbo7u          ^blitz@1.0.2%intel@20.0.166 build_type=RelWithDebInfo arch=linux-sles12-x86_64 
[+]  beblqlk              ^papi@5.6.0%intel@20.0.166 arch=linux-sles12-x86_64 
[+]  efa2lug          ^boost@1.69.0%intel@20.0.166+atomic+chrono~clanglibcpp cxxstd=default +date_time~debug+exception+filesystem+graph~icu+iostreams+locale+log+math+mpi+multithreaded~numpy patches=2ab6c72d03dec6a4ae20220a9dfd5c8c572c5294252155b85c6874d97c323199 ~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave arch=linux-sles12-x86_64 
[+]  xaawq2h              ^bzip2@1.0.6%intel@20.0.166+shared arch=linux-sles12-x86_64 
[+]  caytrce                  ^diffutils@3.6%intel@20.0.166 arch=linux-sles12-x86_64 
[+]  7jo7skd          ^cgal@4.12%intel@20.0.166 build_type=Release ~core~demos~imageio+shared arch=linux-sles12-x86_64 
[+]  bv2habw              ^gmp@6.1.2%intel@20.0.166 arch=linux-sles12-x86_64 
[+]  f5drweh                  ^autoconf@2.69%intel@20.0.166 arch=linux-sles12-x86_64 
[+]  mggfrkm                      ^m4@1.4.18%intel@20.0.166 patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,c0a408fbffb7255fcc75e26bd8edab116fc81d216bfd18b473668b7739a4158e,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8 +sigsegv arch=linux-sles12-x86_64 
[+]  mp32mnc                          ^libsigsegv@2.11%intel@20.0.166 arch=linux-sles12-x86_64 
[+]  r3jixou                  ^automake@1.16.1%intel@20.0.166 arch=linux-sles12-x86_64 
[+]  3i5x62q                  ^libtool@2.4.6%intel@20.0.166 arch=linux-sles12-x86_64 
[+]  pgnl3sw              ^mpfr@4.0.1%intel@20.0.166 arch=linux-sles12-x86_64 
[+]  jebbewu          ^eigen@3.2.10%intel@20.0.166 build_type=RelWithDebInfo +fftw+metis+mpfr+scotch~suitesparse arch=linux-sles12-x86_64 
[+]  d7e54rb              ^fftw@3.3.8%intel@20.0.166+double+float~fma+long_double+mpi~openmp~pfft_patches~quad simd=avx,avx2,sse2 arch=linux-sles12-x86_64 
[+]  z6mlokq              ^metis@5.1.0%intel@20.0.166 build_type=Release ~gdb~int64 patches=4991da938c1d3a1d3dea78e49bbebecba00273f98df2a656e38b83d55b281da1 +real64+shared arch=linux-sles12-x86_64 
[+]  cko7hy3              ^scotch@6.0.6%intel@20.0.166+compression~esmumps~int64+metis+mpi+shared arch=linux-sles12-x86_64 
[+]  aontsm3                  ^bison@3.0.5%intel@20.0.166 arch=linux-sles12-x86_64 
[+]  5zbs7ul                      ^help2man@1.47.4%intel@20.0.166 arch=linux-sles12-x86_64 
[+]  pbbexlk                          ^gettext@0.19.8.1%intel@20.0.166+bzip2+curses+git~libunistring+libxml2 patches=9acdb4e73f67c241b5ef32505c9ddf7cf6884ca8ea661692f21dca28483b04b8 +tar+xz arch=linux-sles12-x86_64 
[+]  dkojgty                              ^libxml2@2.9.8%intel@20.0.166~python arch=linux-sles12-x86_64 
[+]  pqlypfo                                  ^libiconv@1.15%intel@20.0.166 arch=linux-sles12-x86_64 
[+]  ggtut6p                                  ^xz@5.2.4%intel@20.0.166 arch=linux-sles12-x86_64 
[+]  sndz6j7                              ^tar@1.30%intel@20.0.166 arch=linux-sles12-x86_64 
[+]  3pndf5i                  ^flex@2.6.1%intel@20.0.166+lex arch=linux-sles12-x86_64 
[+]  5zdscwl          ^googletest@1.8.1%intel@20.0.166 build_type=RelWithDebInfo ~gmock+pthreads+shared arch=linux-sles12-x86_64 
[+]  cj5ztki          ^ibmisc@0.2.0%intel@20.0.166+blitz+boost build_type=RelWithDebInfo copy=standard ~doc+everytrace+googletest+netcdf+proj+python+udunits2 arch=linux-sles12-x86_64 
[+]  iwz6754              ^netcdf@4.4.0%intel@20.0.166~dap~hdf4 maxdims=1024 maxvars=8192 +mpi~parallel-netcdf+pic+shared arch=linux-sles12-x86_64 
[+]  zynd7jq                  ^hdf5@1.8.18%intel@20.0.166~cxx~debug+fortran+hl+mpi+pic+shared~szip~threadsafe arch=linux-sles12-x86_64 
[+]  psi4jl3                      ^numactl@2.0.12%intel@20.0.166 arch=linux-sles12-x86_64 
[+]  vgod2gf              ^netcdf-cxx4@4.3.0%intel@20.0.166 build_type=RelWithDebInfo arch=linux-sles12-x86_64 
[+]  bjtjj74              ^proj@5.0.1%intel@20.0.166 arch=linux-sles12-x86_64 
[+]  r2o2cec              ^py-cython@0.23.5%intel@20.0.166 arch=linux-sles12-x86_64 
[+]  jtxg6er                  ^python@3.5.2%intel@20.0.166+dbm~optimizations patches=123082ab3483ded78e86d7c809e98a804b3465b4683c96bd79a2fd799f572244 +pic~pythoncmd+shared~tk~ucs4 arch=linux-sles12-x86_64 
[+]  ldsspvx                      ^sqlite@3.26.0%intel@20.0.166~functions arch=linux-sles12-x86_64 
[+]  d3pqkvr              ^py-numpy@1.15.2%intel@20.0.166+blas+lapack arch=linux-sles12-x86_64 
[+]  mwxuopu                  ^intel-mkl@2020.0.166%intel@20.0.166~ilp64+shared threads=none arch=linux-sles12-x86_64 
[+]  x3yw3lq                  ^py-setuptools@40.4.3%intel@20.0.166 arch=linux-sles12-x86_64 
[+]  puztwus              ^udunits2@2.2.24%intel@20.0.166 arch=linux-sles12-x86_64 
[+]  nemt6wp                  ^expat@2.2.5%intel@20.0.166+libbsd arch=linux-sles12-x86_64 
[+]  3t7idzu                      ^libbsd@0.9.1%intel@20.0.166 arch=linux-sles12-x86_64 
[+]  26ctvho          ^petsc@3.7.7%intel@20.0.166~X clanguage=C ~complex~debug+double~fortran+hdf5+hypre~int64~metis+mpi~mumps patches=22392530068e375ce8b62a1f552b43fbfd2e20822002c69dbafab4d3fa787cbb +shared~suite-sparse~superlu-dist~trilinos arch=linux-sles12-x86_64 
[+]  73pp27y              ^hypre@2.13.0%intel@20.0.166~debug~int64~internal-superlu+mpi+shared arch=linux-sles12-x86_64 
[+]  36odvrq          ^pism@icebin%intel@20.0.166 build_type=RelWithDebInfo copy=standard ~doc+everytrace+examples~extra+icebin~parallel-hdf5~parallel-netcdf3~parallel-netcdf4+proj~python+shared arch=linux-sles12-x86_64 
[+]  3o5fsty              ^gsl@2.5%intel@20.0.166 arch=linux-sles12-x86_64 
[+]  odov7tx          ^tclap@1.2.2%intel@20.0.166 arch=linux-sles12-x86_64 
[+]  fmti6pa      ^netcdf-fortran@4.4.4%intel@20.0.166+pic arch=linux-sles12-x86_64 
[+]  cxqo2je      ^parallel-netcdf@1.11.0%intel@20.0.166~cxx+fortran+pic arch=linux-sles12-x86_64 
[+]  up6gtt5      ^pfunit@3.2.9%intel@20.0.166 build_type=RelWithDebInfo ~docs+mpi~openmp+shared~use_comm_world arch=linux-sles12-x86_64 
```
</details>